### PR TITLE
Use statically checked enum to define colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Capture pretty codeframes.
 
 ```rust
-use codeframe::Codeframe;
+use codeframe::{Color, Codeframe};
 
 let raw_lines = "macro_rules! test_simple_style {
     ($string:expr, $style:ident) => {
@@ -22,7 +22,7 @@ let raw_lines = "macro_rules! test_simple_style {
         }
     };
 }";
-let codeframe = Codeframe::new(raw_lines, 5).set_color("red").capture();
+let codeframe = Codeframe::new(raw_lines, 5).set_color(Color::Red).capture();
 ```
 
 ![Imgur](https://i.imgur.com/vJzKeCr.png)

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -8,7 +8,7 @@ const DEFAULT_START_LINE: i64 = 1;
 const MAX_CODEFRAME_LENGTH: usize = 100;
 const MIN_CODEFRAME_LENGTH: usize = 5;
 
-pub fn capture_code_frame(lines: Vec<&str>, line: i64, color: &str) -> Option<String> {
+pub fn capture_code_frame(lines: Vec<&str>, line: i64, color: crate::Color) -> Option<String> {
     let mut result = String::new();
     let call_line = line;
     let mut start_loc: i64 = call_line - DEFAULT_LINE_ABOVE;

--- a/src/codeframe_builder.rs
+++ b/src/codeframe_builder.rs
@@ -18,7 +18,7 @@
 use crate::capture;
 
 pub struct Codeframe<'a> {
-    color: &'a str,
+    color: crate::Color,
     line: i64,
     raw_lines: &'a str,
 }
@@ -26,13 +26,13 @@ pub struct Codeframe<'a> {
 impl<'a> Codeframe<'a> {
     pub fn new(raw_lines: &'a str, line: i64) -> Codeframe<'a> {
         Codeframe {
-            color: "red",
+            color: crate::Color::Red,
             line,
             raw_lines,
         }
     }
 
-    pub fn set_color(mut self, color: &'a str) -> Self {
+    pub fn set_color(mut self, color: crate::Color) -> Self {
         self.color = color;
         self
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,17 +1,28 @@
 use colored::*;
 
-pub fn color_line(line: &str, color: &str) -> String {
-    let streamlined_color = &color.to_lowercase()[..];
-    match streamlined_color {
-        "black" => line.black().to_string(),
-        "red" => line.red().to_string(),
-        "green" => line.green().to_string(),
-        "yellow" => line.yellow().to_string(),
-        "blue" => line.blue().to_string(),
-        "magenta" => line.magenta().to_string(),
-        "purple" => line.purple().to_string(),
-        "cyan" => line.cyan().to_string(),
-        "white" => line.white().to_string(),
-        _ => line.red().to_string(),
+#[derive(Clone, Copy)]
+pub enum Color {
+    Black,
+    Blue,
+    Cyan,
+    Green,
+    Magenta,
+    Purple,
+    Red,
+    White,
+    Yellow,
+}
+
+pub fn color_line(line: &str, color: Color) -> String {
+    match color {
+        Color::Black => line.black().to_string(),
+        Color::Red => line.red().to_string(),
+        Color::Green => line.green().to_string(),
+        Color::Yellow => line.yellow().to_string(),
+        Color::Blue => line.blue().to_string(),
+        Color::Magenta => line.magenta().to_string(),
+        Color::Purple => line.purple().to_string(),
+        Color::Cyan => line.cyan().to_string(),
+        Color::White => line.white().to_string(),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,5 @@ mod color;
 mod utils;
 
 pub use crate::codeframe_builder::Codeframe;
+
+pub use color::Color;

--- a/tests/builder_test.rs
+++ b/tests/builder_test.rs
@@ -1,11 +1,10 @@
-use codeframe::Codeframe;
-extern crate k9;
+use codeframe::{Codeframe, Color};
 
 #[test]
 fn simple_capture() {
     setup_test_env();
     let raw_lines = "let a: i64 = 12;";
-    let codeframe = Codeframe::new(raw_lines, 1).set_color("red").capture();
+    let codeframe = Codeframe::new(raw_lines, 1).set_color(Color::Red).capture();
     k9::assert_equal!(
         Some("\u{1b}[31m1 | let a: i64 = 12;\u{1b}[0m\n".to_owned()),
         codeframe
@@ -22,7 +21,7 @@ fn simple_capture() {
         }
     };
 }";
-    let codeframe = Codeframe::new(raw_lines, 5).set_color("Red").capture();
+    let codeframe = Codeframe::new(raw_lines, 5).set_color(Color::Red).capture();
 
     k9::assert_equal!(
         Some("\u{1b}[2m3 |         #[test]\u{1b}[0m\n\u{1b}[2m4 |         fn $style() {\u{1b}[0m\n\u{1b}[31m5 |             assert_eq!(\u{1b}[0m\n\u{1b}[31m6 |                 s.$style().to_string(),\u{1b}[0m\n\u{1b}[31m7 |                 ansi_term::Style::new().$style().paint(s).to_string()\u{1b}[0m\n\u{1b}[31m8 |             )\u{1b}[0m\n".to_owned()),
@@ -34,7 +33,9 @@ fn simple_capture() {
 fn out_of_bound_line_number() {
     setup_test_env();
     let raw_lines = "let a: i64 = 12;";
-    let codeframe = Codeframe::new(raw_lines, 2).set_color("black").capture();
+    let codeframe = Codeframe::new(raw_lines, 2)
+        .set_color(Color::Black)
+        .capture();
     k9::assert_equal!(
         Some("\u{1b}[2m1 | let a: i64 = 12;\u{1b}[0m\n".to_owned()),
         codeframe


### PR DESCRIPTION
using raw string to configure colors have multiple issues:
- they have runtime cost
- they're not statically checked (`"bulee"` will resolve to red)
- no autocomplete in the editor

let's use rust's type system to our advantage and have a typechecked color enum